### PR TITLE
Fix URL

### DIFF
--- a/orderly_config.yml
+++ b/orderly_config.yml
@@ -4,7 +4,7 @@ remote:
     args:
       host: hiv-orderly.dide.ic.ac.uk
       port: 443
-      prefix: inference_data
+      prefix: inference-data
       token: $ORDERLYWEB_GITHUB_TOKEN
     primary: true
     default_branch: main

--- a/orderly_config.yml
+++ b/orderly_config.yml
@@ -8,15 +8,16 @@ remote:
       token: $ORDERLYWEB_GITHUB_TOKEN
     primary: true
     default_branch: main
-  # main:
-  #   driver: orderlyweb::orderlyweb_remote
-  #   args:
-  #     host: hiv-orderly.dide.ic.ac.uk
-  #     port: 443
-  #     prefix: fertility
-  #     token: $ORDERLYWEB_GITHUB_TOKEN
-  #   primary: true
-  #   master_only: true
+  fertility:
+    driver: orderlyweb::orderlyweb_remote
+    args:
+      host: hiv-orderly.dide.ic.ac.uk
+      port: 443
+      prefix: fertility
+      token: $ORDERLYWEB_GITHUB_TOKEN
+    primary: false
+    default_branch: main
+    default_branch_only: true
   naomi2:
     driver: orderly.sharepoint::orderly_remote_sharepoint
     args:
@@ -35,3 +36,5 @@ vault:
 
 global_resources:
   global
+
+minimum_orderly_version: 1.4.9


### PR DESCRIPTION
This PR fixes the prefix used for inference-data, leading to the 404 error

I've re-enabled the "main" remote too, though called it fertility. This works for me and I could not replicate the error in the original Teams message