### PR TITLE
Uga 2023 updates

### DIFF
--- a/src/aaa_areas_pull/orderly.yml
+++ b/src/aaa_areas_pull/orderly.yml
@@ -29,161 +29,159 @@ global_resources:
 ## Ideally, keep this list alphabetised for convenience
 
 depends:
-#   ago_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/ago_areas.geojson: ago_areas.geojson
-#   ben_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/ben_areas_spectrum_national.geojson: ben_areas_spectrum_national.geojson
-#   bdi_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/bdi_areas.geojson: bdi_areas.geojson
-#   bfa_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/bfa_areas.geojson: bfa_areas.geojson
-#   bwa_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/bwa_areas.geojson: bwa_areas.geojson
-#   caf_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/caf_areas.geojson: caf_areas.geojson
-#   civ_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/civ_areas.geojson: civ_areas.geojson
-#   cmr_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/cmr_areas.geojson: cmr_areas.geojson
-#   cog_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/cog_areas.geojson: cog_areas.geojson
-#   cod_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/cod_areas.geojson: cod_areas.geojson
-#   eth_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/eth_areas.geojson: eth_areas.geojson
-#   gab_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/gab_areas.geojson: gab_areas.geojson
-#   gha_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/gha_areas.geojson: gha_areas.geojson
-#   gin_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/gin_areas.geojson: gin_areas.geojson
-#   gmb_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/gmb_areas.geojson: gmb_areas.geojson
-#   gnb_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/gnb_areas.geojson: gnb_areas.geojson
-#   gnq_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/gnq_areas.geojson: gnq_areas.geojson
-#   hti_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/hti_areas.geojson: hti_areas.geojson
-#   ken_data_areas_subcounty:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/ken_areas_subcounty.geojson: ken_areas_subcounty.geojson
-#   lbr_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/lbr_areas.geojson: lbr_areas.geojson
-#   lso_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/lso_areas.geojson: lso_areas.geojson
-#   mli_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/mli_areas.geojson: mli_areas.geojson
-#   moz_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/moz_areas.geojson: moz_areas.geojson
-#   mwi_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/mwi_areas.geojson: mwi_areas.geojson
-#   nam_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/nam_areas.geojson: nam_areas.geojson
-#   ner_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/ner_areas.geojson: ner_areas.geojson
-#   nga_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/nga_areas.geojson: nga_areas.geojson
-#   rwa_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/rwa_areas.geojson: rwa_areas.geojson
-#   sen_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/sen_areas.geojson: sen_areas.geojson
-#   sle_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/sle_areas.geojson: sle_areas.geojson
-#   ssd_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/ssd_areas.geojson: ssd_areas.geojson
-#   swz_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/swz_areas.geojson: swz_areas.geojson
-#   tcd_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/tcd_areas.geojson: tcd_areas.geojson
-#   tgo_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/tgo_areas_spectrum_national.geojson: tgo_areas_spectrum_national.geojson
-#   tza_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/tza_areas.geojson: tza_areas.geojson
-  
+  ago_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/ago_areas.geojson: ago_areas.geojson
+  ben_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/ben_areas_spectrum_national.geojson: ben_areas_spectrum_national.geojson
+  bdi_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/bdi_areas.geojson: bdi_areas.geojson
+  bfa_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/bfa_areas.geojson: bfa_areas.geojson
+  bwa_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/bwa_areas.geojson: bwa_areas.geojson
+  caf_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/caf_areas.geojson: caf_areas.geojson
+  civ_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/civ_areas.geojson: civ_areas.geojson
+  cmr_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/cmr_areas.geojson: cmr_areas.geojson
+  cog_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/cog_areas.geojson: cog_areas.geojson
+  cod_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/cod_areas.geojson: cod_areas.geojson
+  eth_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/eth_areas.geojson: eth_areas.geojson
+  gab_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/gab_areas.geojson: gab_areas.geojson
+  gha_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/gha_areas.geojson: gha_areas.geojson
+  gin_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/gin_areas.geojson: gin_areas.geojson
+  gmb_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/gmb_areas.geojson: gmb_areas.geojson
+  gnb_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/gnb_areas.geojson: gnb_areas.geojson
+  gnq_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/gnq_areas.geojson: gnq_areas.geojson
+  hti_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/hti_areas.geojson: hti_areas.geojson
+  ken_data_areas_subcounty:
+    id: latest(parameter:version == version)
+    use:
+      depends/ken_areas_subcounty.geojson: ken_areas_subcounty.geojson
+  lbr_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/lbr_areas.geojson: lbr_areas.geojson
+  lso_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/lso_areas.geojson: lso_areas.geojson
+  mli_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/mli_areas.geojson: mli_areas.geojson
+  moz_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/moz_areas.geojson: moz_areas.geojson
+  mwi_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/mwi_areas.geojson: mwi_areas.geojson
+  nam_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/nam_areas.geojson: nam_areas.geojson
+  ner_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/ner_areas.geojson: ner_areas.geojson
+  nga_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/nga_areas.geojson: nga_areas.geojson
+  rwa_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/rwa_areas.geojson: rwa_areas.geojson
+  sen_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/sen_areas.geojson: sen_areas.geojson
+  sle_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/sle_areas.geojson: sle_areas.geojson
+  ssd_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/ssd_areas.geojson: ssd_areas.geojson
+  swz_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/swz_areas.geojson: swz_areas.geojson
+  tcd_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/tcd_areas.geojson: tcd_areas.geojson
+  tgo_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/tgo_areas_spectrum_national.geojson: tgo_areas_spectrum_national.geojson
+  tza_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/tza_areas.geojson: tza_areas.geojson
   uga_data_areas:
     id: latest(parameter:version == version)
     use:
       depends/uga_areas.geojson: uga_areas.geojson
-      
-#   zaf_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/zaf_areas.geojson: zaf_areas.geojson
-#   zmb_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/zmb_areas_spectrum_national.geojson: zmb_areas_spectrum_national.geojson
-#   zwe_data_areas:
-#     id: latest(parameter:version == version)
-#     use:
-#       depends/zwe_areas.geojson: zwe_areas.geojson
+  zaf_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/zaf_areas.geojson: zaf_areas.geojson
+  zmb_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/zmb_areas_spectrum_national.geojson: zmb_areas_spectrum_national.geojson
+  zwe_data_areas:
+    id: latest(parameter:version == version)
+    use:
+      depends/zwe_areas.geojson: zwe_areas.geojson

--- a/src/aaa_areas_pull/orderly.yml
+++ b/src/aaa_areas_pull/orderly.yml
@@ -28,7 +28,7 @@ global_resources:
 ## ensure the imported file is named 'depends/<iso3>_areas.geojson'
 ## Ideally, keep this list alphabetised for convenience
 
- depends:
+# depends:
 #   ago_data_areas:
 #     id: latest(parameter:version == version)
 #     use:

--- a/src/aaa_areas_pull/orderly.yml
+++ b/src/aaa_areas_pull/orderly.yml
@@ -28,160 +28,160 @@ global_resources:
 ## ensure the imported file is named 'depends/<iso3>_areas.geojson'
 ## Ideally, keep this list alphabetised for convenience
 
-depends:
-  ago_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/ago_areas.geojson: ago_areas.geojson
-  ben_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/ben_areas_spectrum_national.geojson: ben_areas_spectrum_national.geojson
-  bdi_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/bdi_areas.geojson: bdi_areas.geojson
-  bfa_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/bfa_areas.geojson: bfa_areas.geojson
-  bwa_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/bwa_areas.geojson: bwa_areas.geojson
-  caf_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/caf_areas.geojson: caf_areas.geojson
-  civ_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/civ_areas.geojson: civ_areas.geojson
-  cmr_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/cmr_areas.geojson: cmr_areas.geojson
-  cog_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/cog_areas.geojson: cog_areas.geojson
-  cod_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/cod_areas.geojson: cod_areas.geojson
-  eth_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/eth_areas.geojson: eth_areas.geojson
-  gab_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/gab_areas.geojson: gab_areas.geojson
-  gha_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/gha_areas.geojson: gha_areas.geojson
-  gin_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/gin_areas.geojson: gin_areas.geojson
-  gmb_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/gmb_areas.geojson: gmb_areas.geojson
-  gnb_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/gnb_areas.geojson: gnb_areas.geojson
-  gnq_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/gnq_areas.geojson: gnq_areas.geojson
-  hti_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/hti_areas.geojson: hti_areas.geojson
-  ken_data_areas_subcounty:
-    id: latest(parameter:version == version)
-    use:
-      depends/ken_areas_subcounty.geojson: ken_areas_subcounty.geojson
-  lbr_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/lbr_areas.geojson: lbr_areas.geojson
-  lso_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/lso_areas.geojson: lso_areas.geojson
-  mli_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/mli_areas.geojson: mli_areas.geojson
-  moz_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/moz_areas.geojson: moz_areas.geojson
-  mwi_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/mwi_areas.geojson: mwi_areas.geojson
-  nam_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/nam_areas.geojson: nam_areas.geojson
-  ner_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/ner_areas.geojson: ner_areas.geojson
-  nga_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/nga_areas.geojson: nga_areas.geojson
-  rwa_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/rwa_areas.geojson: rwa_areas.geojson
-  sen_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/sen_areas.geojson: sen_areas.geojson
-  sle_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/sle_areas.geojson: sle_areas.geojson
-  ssd_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/ssd_areas.geojson: ssd_areas.geojson
-  swz_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/swz_areas.geojson: swz_areas.geojson
-  tcd_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/tcd_areas.geojson: tcd_areas.geojson
-  tgo_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/tgo_areas_spectrum_national.geojson: tgo_areas_spectrum_national.geojson
-  tza_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/tza_areas.geojson: tza_areas.geojson
+# depends:
+#   ago_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/ago_areas.geojson: ago_areas.geojson
+#   ben_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/ben_areas_spectrum_national.geojson: ben_areas_spectrum_national.geojson
+#   bdi_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/bdi_areas.geojson: bdi_areas.geojson
+#   bfa_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/bfa_areas.geojson: bfa_areas.geojson
+#   bwa_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/bwa_areas.geojson: bwa_areas.geojson
+#   caf_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/caf_areas.geojson: caf_areas.geojson
+#   civ_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/civ_areas.geojson: civ_areas.geojson
+#   cmr_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/cmr_areas.geojson: cmr_areas.geojson
+#   cog_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/cog_areas.geojson: cog_areas.geojson
+#   cod_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/cod_areas.geojson: cod_areas.geojson
+#   eth_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/eth_areas.geojson: eth_areas.geojson
+#   gab_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/gab_areas.geojson: gab_areas.geojson
+#   gha_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/gha_areas.geojson: gha_areas.geojson
+#   gin_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/gin_areas.geojson: gin_areas.geojson
+#   gmb_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/gmb_areas.geojson: gmb_areas.geojson
+#   gnb_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/gnb_areas.geojson: gnb_areas.geojson
+#   gnq_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/gnq_areas.geojson: gnq_areas.geojson
+#   hti_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/hti_areas.geojson: hti_areas.geojson
+#   ken_data_areas_subcounty:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/ken_areas_subcounty.geojson: ken_areas_subcounty.geojson
+#   lbr_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/lbr_areas.geojson: lbr_areas.geojson
+#   lso_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/lso_areas.geojson: lso_areas.geojson
+#   mli_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/mli_areas.geojson: mli_areas.geojson
+#   moz_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/moz_areas.geojson: moz_areas.geojson
+#   mwi_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/mwi_areas.geojson: mwi_areas.geojson
+#   nam_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/nam_areas.geojson: nam_areas.geojson
+#   ner_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/ner_areas.geojson: ner_areas.geojson
+#   nga_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/nga_areas.geojson: nga_areas.geojson
+#   rwa_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/rwa_areas.geojson: rwa_areas.geojson
+#   sen_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/sen_areas.geojson: sen_areas.geojson
+#   sle_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/sle_areas.geojson: sle_areas.geojson
+#   ssd_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/ssd_areas.geojson: ssd_areas.geojson
+#   swz_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/swz_areas.geojson: swz_areas.geojson
+#   tcd_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/tcd_areas.geojson: tcd_areas.geojson
+#   tgo_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/tgo_areas_spectrum_national.geojson: tgo_areas_spectrum_national.geojson
+#   tza_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/tza_areas.geojson: tza_areas.geojson
   uga_data_areas:
     id: latest(parameter:version == version)
     use:
       depends/uga_areas.geojson: uga_areas.geojson
-  zaf_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/zaf_areas.geojson: zaf_areas.geojson
-  zmb_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/zmb_areas_spectrum_national.geojson: zmb_areas_spectrum_national.geojson
-  zwe_data_areas:
-    id: latest(parameter:version == version)
-    use:
-      depends/zwe_areas.geojson: zwe_areas.geojson
+#   zaf_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/zaf_areas.geojson: zaf_areas.geojson
+#   zmb_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/zmb_areas_spectrum_national.geojson: zmb_areas_spectrum_national.geojson
+#   zwe_data_areas:
+#     id: latest(parameter:version == version)
+#     use:
+#       depends/zwe_areas.geojson: zwe_areas.geojson

--- a/src/aaa_areas_pull/orderly.yml
+++ b/src/aaa_areas_pull/orderly.yml
@@ -28,7 +28,7 @@ global_resources:
 ## ensure the imported file is named 'depends/<iso3>_areas.geojson'
 ## Ideally, keep this list alphabetised for convenience
 
-# depends:
+ depends:
 #   ago_data_areas:
 #     id: latest(parameter:version == version)
 #     use:
@@ -169,10 +169,12 @@ global_resources:
 #     id: latest(parameter:version == version)
 #     use:
 #       depends/tza_areas.geojson: tza_areas.geojson
+  
   uga_data_areas:
     id: latest(parameter:version == version)
     use:
       depends/uga_areas.geojson: uga_areas.geojson
+      
 #   zaf_data_areas:
 #     id: latest(parameter:version == version)
 #     use:

--- a/src/aaa_areas_pull/orderly.yml
+++ b/src/aaa_areas_pull/orderly.yml
@@ -28,7 +28,7 @@ global_resources:
 ## ensure the imported file is named 'depends/<iso3>_areas.geojson'
 ## Ideally, keep this list alphabetised for convenience
 
-# depends:
+depends:
 #   ago_data_areas:
 #     id: latest(parameter:version == version)
 #     use:

--- a/src/uga_data_areas/orderly.yml
+++ b/src/uga_data_areas/orderly.yml
@@ -14,7 +14,11 @@ artefacts:
       description: Check boundaries
       filenames:
         - uga_area_hierarchy.png
-
+  - staticgraph:
+      description: New districts 2023
+      filenames:
+        - uga_new_districts_2023.png
+        
 displayname: UGA area hierarchy dataset
 
 packages:

--- a/src/uga_data_areas/orderly.yml
+++ b/src/uga_data_areas/orderly.yml
@@ -2,16 +2,13 @@ script: uga_areas.R
 
 parameters:
   version:
-    default: "2022"
+    default: "2023"
 
 artefacts:
   - data:
       description: area hierarchy dataset
       filenames:
         - uga_areas.geojson
-        - uga_area_boundaries.geojson
-        - uga_area_hierarchy.csv
-        - uga_area_levels.csv
         - uga_areas_kalangala-masaka-bridge.geojson
   - staticgraph:
       description: Check boundaries
@@ -19,7 +16,6 @@ artefacts:
         - uga_area_hierarchy.png
 
 displayname: UGA area hierarchy dataset
-
 
 packages:
   - dplyr

--- a/src/uga_data_areas/uga_areas.R
+++ b/src/uga_data_areas/uga_areas.R
@@ -44,18 +44,26 @@ uga_2022 <- ubos2022 %>%
                              "Masaka city" = "Masaka")) %>%
   left_join(heirarchy %>%
               mutate(area_name3 = recode(area_name3, 
-                 "AruaCity" = "Arua city", 
-                 "GuluCity" = "Gulu city", 
-                 "MbararaCity" = "Mbarara city", 
-                 "HoimaCity" = "Hoima city", 
-                 "JinjaCity" = "Jinja city", 
-                 "MbaleCity" = "Mbale city", 
-                 "LiraCity" = "Lira city",
-                 "SorotiCity" = "Soroti city", 
-                 "FortPortalCity" = "Fort portal city", 
-                 "Madi Okollo" = "Madi okollo"
-                 )))
-
+                                         "AruaCity" = "Arua city", 
+                                         "GuluCity" = "Gulu city", 
+                                         "MbararaCity" = "Mbarara city", 
+                                         "HoimaCity" = "Hoima city", 
+                                         "JinjaCity" = "Jinja city", 
+                                         "MbaleCity" = "Mbale city", 
+                                         "LiraCity" = "Lira city",
+                                         "SorotiCity" = "Soroti city", 
+                                         "FortPortalCity" = "Fort portal city", 
+                                         "Madi Okollo" = "Madi okollo"))) %>%
+  mutate(area_name3 = recode(area_name3, 
+         "Arua city" = "Arua City", 
+         "Gulu city" = "Gulu City", 
+          "Mbarara city" = "Mbarara City", 
+          "Hoima city" = "Hoima City", 
+          "Jinja city" = "Jinja City", 
+          "Mbale city" = "Mbale City", 
+          "Lira city" = "Lira City",
+          "Soroti city" = "Soroti City", 
+          "Fort portal city" = "Fort portal City"))
 
 filter(uga_2022, is.na(area_id3))
 
@@ -63,9 +71,21 @@ object_size(uga_2022)
 
 uga_simple2022 <- ms_simplify(uga_2022, keep = 0.1) %>%
   st_make_valid()
+
 object_size(uga_simple2022)
 
 st_is_valid(uga_simple2022)
+
+
+
+# Plot new districts 
+new2022 <- uga_simple2022 %>%
+  filter(nchar(area_id3) == 11)
+
+ggplot() +
+  geom_sf(data = new2022, aes(fill = area_name2)) +
+  geom_sf_text(data = new2022, aes(label = area_name3), colour = "black", 
+               size = 3)
 
 #' # Uganda lakes shapefile
 #' * Sent by Jotham Mubangizi on 27 April 2020; unknown source
@@ -140,7 +160,6 @@ sf::write_sf(uga_areas, "uga_areas.geojson", delete_dsn = TRUE)
 
 
 #' Plot hierarchy
-
 hierarchy_plot <- plot_area_hierarchy_summary(uga_areas)
 
 ggsave("uga_area_hierarchy.png", hierarchy_plot, h = 6, w = 12)

--- a/src/uga_data_areas/uga_areas.R
+++ b/src/uga_data_areas/uga_areas.R
@@ -157,9 +157,17 @@ sf::write_sf(uga_areas, "uga_areas.geojson", delete_dsn = TRUE)
 #' Plot hierarchy
 hierarchy_plot <- plot_area_hierarchy_summary(uga_areas)
 
-ggsave("uga_area_hierarchy.png", hierarchy_plot, h = 6, w = 12)
+# Plot new districts 
+new <- ggplot() +
+  geom_sf(data = uga_long %>% filter(area_level == 2)) +
+  geom_sf(data = new2022, aes(fill = area_name2)) +
+  geom_sf_text(data = new2022, aes(label = area_name3), colour = "black", 
+               size = 3) +
+  naomi::th_map()
+  
+ggsave("uga_new_districts_2023.png", new, h = 6, w = 8)
 
-
+# Add in brdieg between Masaka and Kalangala
 masaka <- filter(uga_areas, area_name == "Masaka")$geometry
 kalangala <- filter(uga_areas, area_name == "Kalangala")$geometry
 

--- a/src/uga_data_areas/uga_areas.R
+++ b/src/uga_data_areas/uga_areas.R
@@ -2,7 +2,8 @@
 #' Source: Uganda Bureau of Statistics
 #' Levels:
 #'   * 1: Region (10)
-#'   * 2: District (136)
+#'   * 2: Sub-region (15)
+#'   * 2: District (145)
 #' Spectrum: National (level 0)
 #' EPP: National (level 0)
 #' EPP Urban/Rural: Yes
@@ -14,18 +15,15 @@ dir.create("check")
 sharepoint <- spud::sharepoint$new("https://imperiallondon.sharepoint.com/")
 
 #' Read in files from SharePoint
-
 naomi_raw_path <- "sites/HIVInferenceGroup-WP/Shared%20Documents/Data/naomi-raw"
 
-urls <- list(ubos2019 = "UGA/2019-11-09/uganda_districts_2019_i.zip",
-             ubos2020 = "UGA/2020-10-13/Uganda_Districts_2020_UBOS_EPSG_4326.zip",
-             uga_pepfar = "UGA/2019-07-10/Uganda_PROD_5_District_DistrictLsib_2019_Jul.zip",
-             ug_lakes = "UGA/2020-04-27/Ug_lakes.zip",
-             ug2021area_id = "UGA/2020-11-25/uga_2021_area_id.csv", 
-             uga2022_boudnaries = "UGA/2022-11-11/uganda_districts.zip"
+urls <- list(ubos2022 = "UGA/2022-11-11%20UBOS%20146%20districts%202022/uganda_districts.zip",
+             uga_2022_area_id  = "UGA/2022-11-11%20UBOS%20146%20districts%202022/uga_2023_area_id.csv",
+             ug_lakes = "UGA/2020-04-27/Ug_lakes.zip"
              ) %>%
   lapply(function(x) file.path(naomi_raw_path, x)) %>%
   lapply(URLencode)
+
 
 files <- lapply(urls, sharepoint$download)
 
@@ -34,141 +32,61 @@ files <- lapply(urls, sharepoint$download)
 ## Revert back to planar geometry
 sf::sf_use_s2(FALSE)
 
-ubos2019 <- read_sf_zip(files$ubos2019)
-ubos2020 <- read_sf_zip(files$ubos2020)
-uga_pepfar <- read_sf_zip(files$uga_pepfar)
-districts_2023 <- read_sf_zip(files$uga2022_boudnaries)
+ubos2022 <- read_sf_zip(files$ubos2022) %>% st_transform(., crs = 4326)
+heirarchy <- read_csv(files$uga_2022_area_id)
 
-ggplot(districts_2023) +
-  geom_sf()
+uga_2022 <- ubos2022 %>%
+  select(area_name3 = District) %>%
+  mutate(area_name3 = str_to_sentence(area_name3), 
+         area_name3 = recode(area_name3, 
+                             "Kassnda" = "Kassanda", 
+                             "Namutunmba" = "Namutumba", 
+                             "Masaka city" = "Masaka")) %>%
+  left_join(heirarchy %>%
+              mutate(area_name3 = recode(area_name3, 
+                 "AruaCity" = "Arua city", 
+                 "GuluCity" = "Gulu city", 
+                 "MbararaCity" = "Mbarara city", 
+                 "HoimaCity" = "Hoima city", 
+                 "JinjaCity" = "Jinja city", 
+                 "MbaleCity" = "Mbale city", 
+                 "LiraCity" = "Lira city",
+                 "SorotiCity" = "Soroti city", 
+                 "FortPortalCity" = "Fort portal city", 
+                 "Madi Okollo" = "Madi okollo"
+                 )))
 
 
-map2023 <- districts_2023 %>%
-  mutate(area_name)
+filter(uga_2022, is.na(area_id3))
 
-map <- read_csv(files$ug2021area_id) %>%
-  select(area_id = area_id3, area_name = area_name3) %>%
-  
+object_size(uga_2022)
 
-#' The file uga_2021_area_id contains the area hierarchy and area_id to assign
-#' corresponding to the 2020 UBOS shape file with one new district (136 total).
-#' The new shape file did not include full region hierarchy, so obtaining that
-#' from this file.
-#' * Arua district split into Arua and Terego
-#' * Former Arua area_id retired and two new area_id assigned for (updated) Arua
-#'   boundaries and Terego boundaries
-
-area_id2021 <- read_csv(files$ug2021area_id)
-
-#' Comparison shape files
-uga_pepfar <- st_make_valid(uga_pepfar)
-
-uga_pepfar0 <- uga_pepfar %>%
-  st_union() %>%
-  ms_simplify(0.05) %>%
+uga_simple2022 <- ms_simplify(uga_2022, keep = 0.1) %>%
   st_make_valid()
+object_size(uga_simple2022)
 
-ggplot(uga_pepfar0) +
-  geom_sf()
+st_is_valid(uga_simple2022)
 
 #' # Uganda lakes shapefile
 #' * Sent by Jotham Mubangizi on 27 April 2020; unknown source
 ug_lakes <- read_sf_zip(files$ug_lakes)
 uga_lakes <- st_transform(ug_lakes, 4326)
 
-#' # Shape file cleaning
-uga_simple <- ubos2020 %>%
-  st_transform(4326) %>%
-  rmapshaper::ms_simplify(0.05) %>%
-  sf::st_make_valid()
-
-uga_simple <- area_id2021 %>%
-  full_join(uga_simple, by = c("LEVEL5" = "X2020")) %>%
-  st_as_sf()
-
-stopifnot(!is.na(uga_simple$area_id3))
-stopifnot(!st_is_empty(uga_simple))
-
-#' Get rid of fragments created by st_make_valid()
-uga_simple <- st_collection_extract(uga_simple, "POLYGON")
-
-#' Review boundary discrepancies
-uga_simple %>%
-  summarise() %>%
-  ggplot() +
-  geom_sf(fill = NA) +
-  th_map()
-
-#' Discrepancy is on the boundary of Kyotera (Rakai / Kyotera / Lwengo / Masaka)
-uga_simple %>%
-  filter(LEVEL3 == "SOUTH BUGANDA") %>%
-  ggplot() +
-  geom_sf() +
-  geom_sf_label(aes(label = LEVEL5)) +
-  th_map()
-
-uga_simple %>%
-  filter(LEVEL3 == "SOUTH BUGANDA") %>%
-  summarise() %>%
-  ggplot() +
-  geom_sf() +
-  th_map()
-
-bad <- uga_simple %>%
-  filter(LEVEL5 %in% c("RAKAI", "KYOTERA", "LWENGO", "MASAKA")) %>%
-  st_transform(3857)
-
-uga_clean <- uga_simple %>%
-  st_transform(3857) %>%
-  st_snap(bad %>% filter(LEVEL5 == "RAKAI"), 500) %>%
-  st_snap(bad %>% filter(LEVEL5 == "KYOTERA"), 500) %>%
-  st_snap(bad %>% filter(LEVEL5 == "LWENGO"), 100) %>%
-  st_snap(bad %>% filter(LEVEL5 == "MASAKA"), 100) %>%
-  st_transform(4326)
-
-uga_clean %>%
-  summarise() %>%
-  ggplot() +
-  geom_sf(fill = NA)
-
-uga_clean %>%
-  filter(LEVEL5 %in% c("KYOTERA", "RAKAI", "LWENGO")) %>%
-  ggplot() +
-  geom_sf(fill = NA)
-
-#' Review cleaning:
-#' * Red lines are original boundaries.
-#' * Grey lines are boundaries after st_snap().
-#' * Black specs are remaining slivers.
-#' Visible red line segments are places where snapping has affected the boundaries.
-
-uga_clean %>%
-  filter(LEVEL5 %in% c("RAKAI", "KYOTERA", "LWENGO", "MASAKA")) %>%
-  {
-    ggplot() +
-      geom_sf(data = bad, color = "red", fill = NA) +
-      geom_sf(data = ., color = "grey", fill = NA) +
-      geom_sf(data = summarise(.), color = "black", fill = NA)
-  }
-
-
 #' Remove lakes
 uga_all_lakes <- st_combine(uga_lakes) %>%
   st_make_valid() %>%
   st_collection_extract() %>%
-  ms_simplify(0.25)
+  ms_simplify(0.25) 
 
-uga_clipped <- st_difference(uga_clean, uga_all_lakes)
-
+uga_clipped <- st_difference(uga_simple2022, uga_all_lakes) %>%
+  st_collection_extract()
 
 ggplot(uga_all_lakes) +
   geom_sf(color = "lightblue4", fill = "lightblue") +
-  geom_sf(data = uga_clean, fill = NA, color = NA) +
   ggtitle("All lakes removed")
 
 ggplot(uga_clipped) +
   geom_sf(fill = "grey70")
-
 
 uga_clipped %>%
   st_union() %>%
@@ -179,7 +97,8 @@ uga_clipped %>%
 #' Recode area hierarchy
 uga_wide <- uga_clipped %>%
   mutate(
-    spectrum_region_code = 0
+    spectrum_region_code = 0, 
+    area_id0 = "UGA",
   ) %>%
   select(area_id0,
          area_name0,
@@ -214,26 +133,10 @@ uga_areas <- uga_long %>%
          pepfar_psnu_level = area_level == 3)
 
 
-uga_area_hierarchy <- uga_areas %>%
-  st_set_geometry(NULL) %>%
-  select(area_id, area_name, area_level, parent_area_id, area_sort_order, center_x, center_y, spectrum_region_code)
-
-uga_area_boundaries <- uga_areas %>%
-  select(area_id, geometry)
-
-uga_area_levels <- uga_areas %>%
-  st_set_geometry(NULL) %>%
-  count(area_level, area_level_label, display, spectrum_level,
-        epp_level, naomi_level, pepfar_psnu_level, name = "n_areas") %>%
-  select(area_level, n_areas, area_level_label, display, spectrum_level,
-         epp_level, naomi_level, pepfar_psnu_level)
-
 #' Save boundaries
+sf::write_sf(bfa_areas, "uga_areas.geojson", delete_dsn = TRUE)
 
-sf::st_write(uga_areas, "uga_areas.geojson", delete_dsn = TRUE)
-sf::st_write(uga_area_boundaries, "uga_area_boundaries.geojson", delete_dsn = TRUE)
-write_csv(uga_area_hierarchy, "uga_area_hierarchy.csv")
-write_csv(uga_area_levels, "uga_area_levels.csv")
+
 
 
 #' Plot hierarchy

--- a/src/uga_data_areas/uga_areas.R
+++ b/src/uga_data_areas/uga_areas.R
@@ -3,12 +3,11 @@
 #' Levels:
 #'   * 1: Region (10)
 #'   * 2: Sub-region (15)
-#'   * 2: District (145)
+#'   * 2: District (146)
 #' Spectrum: National (level 0)
 #' EPP: National (level 0)
 #' EPP Urban/Rural: Yes
 #' PEPFAR PSNU: District (level 2)
-
 dir.create("check")
 
 #' Authenticate SharePoint login
@@ -40,8 +39,8 @@ uga_2022 <- ubos2022 %>%
   mutate(area_name3 = str_to_sentence(area_name3), 
          area_name3 = recode(area_name3, 
                              "Kassnda" = "Kassanda", 
-                             "Namutunmba" = "Namutumba", 
-                             "Masaka city" = "Masaka")) %>%
+                             "Namutunmba" = "Namutumba",
+                             "Masaka city" = "Masaka City")) %>%
   left_join(heirarchy %>%
               mutate(area_name3 = recode(area_name3, 
                                          "AruaCity" = "Arua city", 
@@ -75,7 +74,6 @@ uga_simple2022 <- ms_simplify(uga_2022, keep = 0.1) %>%
 object_size(uga_simple2022)
 
 st_is_valid(uga_simple2022)
-
 
 
 # Plot new districts 
@@ -155,9 +153,6 @@ uga_areas <- uga_long %>%
 
 #' Save boundaries
 sf::write_sf(uga_areas, "uga_areas.geojson", delete_dsn = TRUE)
-
-
-
 
 #' Plot hierarchy
 hierarchy_plot <- plot_area_hierarchy_summary(uga_areas)

--- a/src/uga_data_areas/uga_areas.R
+++ b/src/uga_data_areas/uga_areas.R
@@ -21,7 +21,8 @@ urls <- list(ubos2019 = "UGA/2019-11-09/uganda_districts_2019_i.zip",
              ubos2020 = "UGA/2020-10-13/Uganda_Districts_2020_UBOS_EPSG_4326.zip",
              uga_pepfar = "UGA/2019-07-10/Uganda_PROD_5_District_DistrictLsib_2019_Jul.zip",
              ug_lakes = "UGA/2020-04-27/Ug_lakes.zip",
-             ug2021area_id = "UGA/2020-11-25/uga_2021_area_id.csv"
+             ug2021area_id = "UGA/2020-11-25/uga_2021_area_id.csv", 
+             uga2022_boudnaries = "UGA/2022-11-11/uganda_districts.zip"
              ) %>%
   lapply(function(x) file.path(naomi_raw_path, x)) %>%
   lapply(URLencode)
@@ -36,7 +37,18 @@ sf::sf_use_s2(FALSE)
 ubos2019 <- read_sf_zip(files$ubos2019)
 ubos2020 <- read_sf_zip(files$ubos2020)
 uga_pepfar <- read_sf_zip(files$uga_pepfar)
+districts_2023 <- read_sf_zip(files$uga2022_boudnaries)
 
+ggplot(districts_2023) +
+  geom_sf()
+
+
+map2023 <- districts_2023 %>%
+  mutate(area_name)
+
+map <- read_csv(files$ug2021area_id) %>%
+  select(area_id = area_id3, area_name = area_name3) %>%
+  
 
 #' The file uga_2021_area_id contains the area hierarchy and area_id to assign
 #' corresponding to the 2020 UBOS shape file with one new district (136 total).

--- a/src/uga_data_areas/uga_areas.R
+++ b/src/uga_data_areas/uga_areas.R
@@ -157,6 +157,8 @@ sf::write_sf(uga_areas, "uga_areas.geojson", delete_dsn = TRUE)
 #' Plot hierarchy
 hierarchy_plot <- plot_area_hierarchy_summary(uga_areas)
 
+ggsave("uga_area_hierarchy.png", hierarchy_plot, h = 6, w = 12)
+
 # Plot new districts 
 new <- ggplot() +
   geom_sf(data = uga_long %>% filter(area_level == 2)) +

--- a/src/uga_data_areas/uga_areas.R
+++ b/src/uga_data_areas/uga_areas.R
@@ -134,7 +134,7 @@ uga_areas <- uga_long %>%
 
 
 #' Save boundaries
-sf::write_sf(bfa_areas, "uga_areas.geojson", delete_dsn = TRUE)
+sf::write_sf(uga_areas, "uga_areas.geojson", delete_dsn = TRUE)
 
 
 


### PR DESCRIPTION
This updates UGA areas with boudnaries fro the 2023 naomi estimates. Raw data and correspondence found here: https://imperiallondon.sharepoint.com/:f:/r/sites/HIVInferenceGroup-WP/Shared%20Documents/Data/naomi-raw/UGA/2022-11-11%20UBOS%20146%20districts%202022?csf=1&web=1&e=DFOVYt

Updates:
* 136 districts -> 146 districts



UGA_3_138ks | Gulu City | Curved off from Gulu district and Omoro district
-- | -- | --
UGA_3_139rd | Mbarara City | Curved off from Mbara district
UGA_3_140ap | Hoima City | Curved off from Hoima district
UGA_3_141cf | Jinja City | Curved off from Jinja district
UGA_3_142yf | Mbale City | Curved off from Mbale district
UGA_3_143os | Lira City | Curved off from Lira district
UGA_3_144ih | Soroti City | Curved off from Soroti district
UGA_3_145gu | Fort Portal City | Curved off from Kabarole district
UGA_3_146ps | Arua City | Curved off from Arura and Terego districts(Terego was not curved in creating Arua City)
UGA_3_089kh | Masaka City | Curved off from Masaka and Kalunga and Lwengo district

