### PR TITLE
ssd_data_areas: update with DHIS boundaries

### DIFF
--- a/src/ssd_data_areas/orderly.yml
+++ b/src/ssd_data_areas/orderly.yml
@@ -8,7 +8,7 @@ artefacts:
 
 parameters:
   version:
-    default: 2021
+    default: 2023
 
 packages:
   - tidyverse

--- a/src/ssd_data_areas/script.R
+++ b/src/ssd_data_areas/script.R
@@ -30,6 +30,11 @@ st_is_valid(sh)
 
 sh <- st_make_valid(sh)
 
+
+#' Get rid of fragments created by st_make_valid()
+table(st_geometry_type(sh))
+sh <- st_collection_extract(sh, "POLYGON")
+
 #' Add national (level 0) boundary
 
 sh0 <- sh %>%
@@ -70,8 +75,7 @@ areas <- ids %>%
     display = TRUE
   ) %>%
   st_as_sf() %>%
-  select(area_id, area_name, area_level, parent_area_id, area_sort_order, center_x, center_y, spectrum_region_code, area_level_label, display, spectrum_level, epp_level, naomi_level, pepfar_psnu_level) %>%
-  st_make_valid()
+  select(area_id, area_name, area_level, parent_area_id, area_sort_order, center_x, center_y, spectrum_region_code, area_level_label, display, spectrum_level, epp_level, naomi_level, pepfar_psnu_level) 
 
 areas <- filter(areas, !st_is_empty(areas))
 

--- a/src/ssd_data_areas/script.R
+++ b/src/ssd_data_areas/script.R
@@ -46,6 +46,9 @@ areas <- ids %>%
     by = "parent_area_id_ADR"
   ) %>%
   mutate(
+    area_name = area_name %>%
+      sub(" State", "", .) %>%
+      sub(" County", "", .),
     area_level_label = area_level %>%
       recode(`0` = "Country", `1` = "State", `2` = "County"),
     spectrum_level = as.logical(area_level == 0),


### PR DESCRIPTION
This has 79 counties. Akoka county is dropped because it is missing from boundaries data set. This was determined through discussion with SSD team.

I have run this locally and sent to SSD team, but not on orderlyweb.