### PR TITLE
GHA 2023: clean up geom fragments using st_cast

### DIFF
--- a/src/gha_data_areas/gha_areas.R
+++ b/src/gha_data_areas/gha_areas.R
@@ -97,7 +97,8 @@ gha_clean <- gha_long %>%
   st_transform(3857) %>%
   st_snap(., ., tolerance = 50) %>%
   sf::st_make_valid() %>%
-  st_transform(4326)
+  st_transform(4326) %>%
+  st_cast(.,"MULTIPOLYGON")
 
 p <- ggplot() +
   geom_sf(data = gha_long %>% filter(area_level == 1), fill = NA, color = "black") +


### PR DESCRIPTION
Small PR to clean up multipolygon fragments created from overlapping boundaries.
This wasn't flagged as an issue in our workflow but throws a validation error on the ADR and creates issues in ArcGIS.